### PR TITLE
5G Pay was renamed to Zastrpay

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ Moirae Software Engineering Ltd | UK | Software | [Twitter](https://twitter.com/
 [Welendus](https://welendus.com) | USA, TX, Dallas | FinTech | [Website](https://welendus.com) | 
 [White Oak AM](https://www.whiteoakam.com/) | Switzerland, Geneva | Finance | [Website](https://www.whiteoakam.com/) | No
 [Wyatt Technology](https://www.wyatt.com/) | USA, CA, Santa Barbara | Analytical Instruments |  | Ok
-[Zastrpay Studios GmbH](https://zastrpay.com/) | Austria, Vienna | Software | | Ok
+[Zastrpay Studios GmbH](https://zastrpay.com/) | Austria, Vienna | Software | | Hybrid (Austria)
 [Zühlke Engineering](https://www.zuehlke.com/) | Germany | Software | | 

--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ Moirae Software Engineering Ltd | UK | Software | [Twitter](https://twitter.com/
 [Welendus](https://welendus.com) | USA, TX, Dallas | FinTech | [Website](https://welendus.com) | 
 [White Oak AM](https://www.whiteoakam.com/) | Switzerland, Geneva | Finance | [Website](https://www.whiteoakam.com/) | No
 [Wyatt Technology](https://www.wyatt.com/) | USA, CA, Santa Barbara | Analytical Instruments |  | Ok
-[ZastrPay](https://zastrpay.com/) | Austria, Vienna | Software | | Ok
+[Zastrpay Studios GmbH](https://zastrpay.com/) | Austria, Vienna | Software | | Ok
 [Zühlke Engineering](https://www.zuehlke.com/) | Germany | Software | | 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If your company loves and benefits from using F#, consider submitting a [testimo
 | Name | Location | Sector | Source | Remote OK? |
 | :--- | :------- | :----- | :----- | :--------- |
 [1WorldSync](https://1worldsync.com/) | Chicago | Software | |
-[5G Pay](https://5gpay.com/) | Austria, Vienna | Software | [Blog](https://5gpay.com/blog) | Ok
 [69 Grad](https://69grad.de/) | Germany, Munich | Software | [Blog](https://thomasbandt.com) | Ok
 [Abramad](https://www.abramad.com/) | Tehran, Iran | Cloud Services | | Ok (Iran only)
 [Acadian Ambulance](https://www.acadian.com/) | USA, LA, Lafayette | Healthcare | [GitHub](https://github.com/Acadian-Ambulance/) | Ok
@@ -141,4 +140,5 @@ Moirae Software Engineering Ltd | UK | Software | [Twitter](https://twitter.com/
 [Welendus](https://welendus.com) | USA, TX, Dallas | FinTech | [Website](https://welendus.com) | 
 [White Oak AM](https://www.whiteoakam.com/) | Switzerland, Geneva | Finance | [Website](https://www.whiteoakam.com/) | No
 [Wyatt Technology](https://www.wyatt.com/) | USA, CA, Santa Barbara | Analytical Instruments |  | Ok
+[ZastrPay](https://zastrpay.com/) | Austria, Vienna | Software | | Ok
 [Zühlke Engineering](https://www.zuehlke.com/) | Germany | Software | | 


### PR DESCRIPTION
The blog seems to have not been moved to the new web page. The old url links to new page though. The company and their F# commitment is still strong. Saw a presentation at the vienna F# meetup.